### PR TITLE
Add ipykernel to pyproject.toml

### DIFF
--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -9,6 +9,7 @@ python = "{{ cookiecutter.compatible_python_versions }}"
 dvc = "^2.10.0"
 hydra-core = "^1.1.1"
 pdoc3 = "^0.10.0"
+ipykernel = "^6.28.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
Running Jupyter notebooks requires `ipykernel`. This PR suggests adding it to `pyproject.toml` by default.