### PR TITLE
Print hydra config file

### DIFF
--- a/{{cookiecutter.directory_name}}/config/print_hydra.py
+++ b/{{cookiecutter.directory_name}}/config/print_hydra.py
@@ -1,0 +1,14 @@
+"""
+Print the hydra configuration file
+"""
+
+import hydra
+from omegaconf import DictConfig, OmegaConf
+
+
+@hydra.main(version_base=None, config_path="./", config_name="main")
+def process_data(config: DictConfig) -> None:
+    print(OmegaConf.to_yaml(config))
+
+if __name__ == "__main__":
+    process_data()

--- a/{{cookiecutter.directory_name}}/config/print_hydra.py
+++ b/{{cookiecutter.directory_name}}/config/print_hydra.py
@@ -5,10 +5,9 @@ Print the hydra configuration file
 import hydra
 from omegaconf import DictConfig, OmegaConf
 
-
 @hydra.main(version_base=None, config_path="./", config_name="main")
-def process_data(config: DictConfig) -> None:
+def print_hydra(config: DictConfig) -> None:
     print(OmegaConf.to_yaml(config))
 
 if __name__ == "__main__":
-    process_data()
+    print_hydra()

--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -9,6 +9,7 @@ python = "{{ cookiecutter.compatible_python_versions }}"
 dvc = "^2.10.0"
 hydra-core = "^1.1.1"
 pdoc3 = "^0.10.0"
+ipykernel = "^6.28.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -9,7 +9,6 @@ python = "{{ cookiecutter.compatible_python_versions }}"
 dvc = "^2.10.0"
 hydra-core = "^1.1.1"
 pdoc3 = "^0.10.0"
-ipykernel = "^6.28.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
As your config file gets complex, it might be handy to have a simple python code to print out the config structure:

[Screencast from 14-01-2024 19:46:05.webm](https://github.com/khuyentran1401/data-science-template/assets/22801918/f6306a07-0abd-40b5-ad3a-d78e3da2690d)

You may also find interesting to have such a .py file by default in your template :)