### PR TITLE
Add --no-root

### DIFF
--- a/{{cookiecutter.directory_name}}/Makefile
+++ b/{{cookiecutter.directory_name}}/Makefile
@@ -4,7 +4,7 @@ dependencies:
 	@echo "Initializing Git..."
 	git init
 	@echo "Installing dependencies..."
-	poetry install
+	poetry install --no-root
 	poetry run pre-commit install
 
 env: dependencies


### PR DESCRIPTION
Without the `--no-root` option, the `Makefile` wrongly tries to install the Python project, which is not desired.

![image](https://github.com/khuyentran1401/data-science-template/assets/22801918/4682d8d5-4608-4c9b-a691-796c6ace6712)


This PR fix it.