### PR TITLE
[tools.poetry.dev-dependencies] is deprecated / add hydra multirun log directory to .gitignore / poetry shell not bundled with poetry >=2.0.0 anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository provides a template that incorporates best practices to create a
 * [pdoc](https://github.com/pdoc3/pdoc): Automatically create an API documentation for your project
 * [pre-commit plugins](https://pre-commit.com/): Automate code reviewing formatting
 * [Poetry](https://towardsdatascience.com/how-to-effortlessly-publish-your-python-package-to-pypi-using-poetry-44b305362f9f): Dependency management - [article](https://codecut.ai/poetry-a-better-way-to-manage-python-dependencies/)
+* [Poetry Shell Plugin](https://github.com/python-poetry/poetry-plugin-shell): Open a shell with already activated poetry venv (bundled with poetry prior to 2.0.0)
 
 ## How to use this project
 

--- a/{{cookiecutter.__directory_name}}/.gitignore
+++ b/{{cookiecutter.__directory_name}}/.gitignore
@@ -91,6 +91,7 @@ target/
 
 # Hydra logs
 outputs
+multirun
 
 # Data
 data/*/*

--- a/{{cookiecutter.__directory_name}}/Makefile
+++ b/{{cookiecutter.__directory_name}}/Makefile
@@ -7,6 +7,7 @@ deps:
 	@echo "Installing dependencies..."
 	poetry install --no-root
 	poetry run pre-commit install
+	poetry self add poetry-plugin-shell
 	{% else %}
 	@echo "Installing dependencies..."
 	pip install -r requirements-dev.txt

--- a/{{cookiecutter.__directory_name}}/README.md
+++ b/{{cookiecutter.__directory_name}}/README.md
@@ -6,6 +6,7 @@
 * [pre-commit plugins](https://pre-commit.com/): Automate code reviewing formatting
 {% if cookiecutter.dependency_manager == "poetry" %}
 * [Poetry](https://towardsdatascience.com/how-to-effortlessly-publish-your-python-package-to-pypi-using-poetry-44b305362f9f): Dependency management - [article](https://mathdatasimplified.com/poetry-a-better-way-to-manage-python-dependencies/)
+* [Poetry Shell Plugin](https://github.com/python-poetry/poetry-plugin-shell): Open a shell with already activated poetry venv (bundled with poetry prior to 2.0.0)
 {% endif %}
 
 ## Project Structure

--- a/{{cookiecutter.__directory_name}}/pyproject.toml
+++ b/{{cookiecutter.__directory_name}}/pyproject.toml
@@ -9,7 +9,7 @@ authors = ["{{ cookiecutter.author_name }}"]
 python = "{{ cookiecutter.compatible_python_versions }}"
 hydra-core = "^1.1.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pdoc3 = "^0.10.0"
 pytest = "^6.2.5"
 pre-commit = "^2.17.0"


### PR DESCRIPTION
Fix [Issue 24](https://github.com/khuyentran1401/data-science-template/issues/24) from upstream repository.

**Improvements:**
- Install `poetry shell plugin` in new step in `makefile` if poetry is chosen as a dependency manager
- Add `multirun` directory to `.gitignore` to ignore logs from hydra runs with multirun (`-m`) option

**Fixes:**
- Change dev-dependency identifier in `pyproject.toml` from `[tool.poetry.dev-dependencies]` to `[tools.poetry.group.dev.dependencies]` as the prior one is deprecated in `poetry >= 2.0.0`