### PR TITLE
Bump pre-commit hooks' versions to latest stable release

### DIFF
--- a/{{cookiecutter.__directory_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.__directory_name}}/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.2.0"
+    rev: v0.11.6
     hooks:
       - id: ruff
         args: [--fix]
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.10.0"
+    rev: v1.15.0
     hooks:
       - id: mypy


### PR DESCRIPTION
Bump versions manually as discussed. `"` are not needed, as the values here will be parsed as strings in yaml right away anyway (as they are not matching the number format).

Tested locally.